### PR TITLE
Maubot port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ bin
 config*.json
 !config.sample.json
 .direnv
-standupbot
+/standupbot
 passwordfile
 .envrc.user
 *.swp

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ standupbot
 passwordfile
 .envrc.user
 *.swp
+
+# maubot plugin build artifacts
+*.mbp
+__pycache__/
+*.pyc

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,455 @@
+# Standupbot Modernization Plan
+
+## Problem
+
+Standupbot uses `maunium.net/go/mautrix` v0.10.12 (circa 2021). This version
+predates the authentication changes required by current Fedora Matrix
+homeservers. The bot cannot connect to modern Matrix infrastructure without
+upgrading its Matrix client library.
+
+## Current Codebase Summary
+
+| Component            | File(s)                                    | Lines |
+|----------------------|--------------------------------------------|-------|
+| Main / sync loop     | `standupbot.go`                            | 345   |
+| Commands & routing   | `command_handler.go`                       | 707   |
+| Post creation        | `create_post.go`                           | 350   |
+| Send helpers         | `helper.go`                                | 88    |
+| Config loading       | `configuration.go`                         | 24    |
+| Crypto logger        | `crypto-logger.go`                         | 27    |
+| Store (state/sync)   | `store/store.go`, `storer.go`              | 189   |
+| Store (user config)  | `store/config_room.go`                     | 159   |
+| Store (crypto)       | `store/crypto_state_store.go`              | 122   |
+| Custom event types   | `types/state_events.go`                    | 27    |
+| **Total**            |                                            | **2038** |
+
+**Key dependencies:** mautrix v0.10.12, logrus, go-sqlite3, libolm (C),
+google/uuid, kyoh86/xdg, sethvargo/go-retry.
+
+**Bot features:** DM-based standup flow (Done/Planned/Blockers/Notes), thread
+mode, reaction-based confirm/cancel, post editing after send, scheduled
+notifications, E2E encryption (Olm/Megolm), user config via Matrix state
+events, flow persistence across restarts.
+
+---
+
+## Option A: Update mautrix-go to Latest (v0.27.0)
+
+### What changes
+
+Upgrade from v0.10.12 → v0.27.0, adapting to 5 years of breaking changes.
+Keep the existing Go binary architecture. No new frameworks.
+
+### Breaking changes to address
+
+| mautrix version | Breaking change | Impact on standupbot |
+|-----------------|-----------------|----------------------|
+| v0.15 | Logging switched from maulogger to **zerolog** | Replace all logrus usage with zerolog, or adapt the crypto logger interface |
+| v0.17 | **`context.Context` required** on all client calls | Add `ctx` parameter to every `client.*` call (~50+ call sites) |
+| v0.17 | `EventSource` moved from handler param to `event.Source` field | Update all syncer handler signatures (6 handlers) |
+| v0.17 | OlmMachine API changes (context params) | Update crypto init, decrypt, encrypt calls |
+| v0.21 | Unauthenticated media dropped | Verify no media usage (standupbot doesn't use media — no impact) |
+| v0.25 | gorilla/mux → stdlib ServeMux | No impact (standupbot doesn't run an HTTP server) |
+| v0.27 | Removed auto gob registrations, PK encryption removals | Minor — update crypto store init |
+| Ongoing | libolm deprecated → **goolm** (pure Go) | Drop C dependency on libolm; simplify Docker build |
+
+### Implementation plan
+
+#### Phase 1: Dependency update and compilation (1–2 days)
+
+1. Update `go.mod`: bump Go version to 1.21+, update mautrix to v0.27.0.
+2. Run `go build` — collect all compilation errors.
+3. Fix import path changes (if any sub-packages moved).
+
+#### Phase 2: Context threading (1–2 days)
+
+Every client method now requires `context.Context`. This is the largest
+mechanical change.
+
+1. Add `ctx context.Context` to `SendMessage()`, `SendReaction()` in
+   `helper.go`.
+2. Thread context through `HandleMessage()`, `HandleReaction()`,
+   `HandleRedaction()` in `command_handler.go`.
+3. Thread context through `CreatePost()` and all post-send helpers in
+   `create_post.go`.
+4. Update `main()`: pass `context.Background()` to login, sync, joined-rooms,
+   members, state-event calls.
+5. Update store methods if the `Storer` interface now requires context.
+
+#### Phase 3: Event handler signature update (0.5 day)
+
+The syncer handler signature changed — `EventSource` is no longer a parameter.
+
+```go
+// Old (v0.10):
+syncer.OnEventType(mevent.EventMessage, func(source mautrix.EventSource, event *mevent.Event) { ... })
+
+// New (v0.17+):
+syncer.OnEventType(mevent.EventMessage, func(event *mevent.Event) { ... })
+// Access source via event.Source
+```
+
+Update all 6 handlers in `standupbot.go` (lines 257–300).
+
+#### Phase 4: Crypto / OlmMachine update (1 day)
+
+1. Switch from libolm (C library) to goolm (pure Go) — remove `olm-dev` from
+   Dockerfile.
+2. Update `NewSQLCryptoStore()` call if constructor signature changed.
+3. Update `NewOlmMachine()` — likely now requires context and has a different
+   logger interface.
+4. Update `DecryptMegolmEvent()` and encrypt paths to pass context.
+5. Update `ProcessSyncResponse()` and `HandleMemberEvent()` signatures.
+
+#### Phase 5: Logging migration (0.5–1 day)
+
+mautrix v0.15+ uses zerolog internally. Options:
+
+- **Option A (recommended):** Switch standupbot to zerolog too. Replace logrus
+  calls (~40 sites) with zerolog equivalents. Keeps one logging library.
+- **Option B:** Keep logrus for standupbot's own logging, implement the new
+  crypto logger interface to bridge to logrus. Results in two logging
+  libraries.
+
+#### Phase 6: Dockerfile and build modernization (0.5 day)
+
+1. Update base image from `golang:1-alpine3.16` to current Alpine.
+2. Remove `olm-dev` / `olm` packages (no longer needed with goolm).
+3. Update Go version to 1.21+.
+4. Test multi-stage build produces working binary.
+
+#### Phase 7: Testing and validation (1–2 days)
+
+1. Test login against Fedora Matrix homeserver with new auth.
+2. Test E2E encryption (key exchange, message decrypt/encrypt).
+3. Test full standup flow: new → items → confirm → send.
+4. Test thread mode, edit-after-send, undo.
+5. Test notification scheduling.
+6. Test flow persistence across restart.
+7. Test invite/join handling.
+
+### Risks
+
+- **Crypto state migration:** Existing Olm sessions in the SQLite DB may not
+  be compatible with goolm's storage format. May need to wipe crypto state and
+  re-verify devices.
+- **Untested API surface:** mautrix doesn't have a formal migration guide.
+  Some changes may only surface at runtime (e.g., new required fields in
+  requests).
+- **goolm maturity:** goolm is newer than libolm. The April 2026 release notes
+  mention ongoing hardening. Ed25519 key storage differences have been found
+  via differential fuzzing.
+
+### Estimated effort
+
+**5–8 days** of focused development, assuming familiarity with the codebase.
+
+### What you get
+
+- Working bot on modern Fedora Matrix homeservers.
+- Pure Go binary (no C dependencies).
+- Same architecture, same deployment model, same features.
+- Position to adopt future mautrix improvements incrementally.
+
+---
+
+## Option B: Rewrite as a Maubot Plugin (Python) — SELECTED
+
+### Decisions
+
+| Decision                   | Choice                                       |
+|----------------------------|----------------------------------------------|
+| **Database backend**       | Support both aiosqlite and asyncpg (config-time choice) |
+| **User config storage**    | Matrix room state events (preserve existing `com.nevarro.standupbot.*` events) |
+| **Flow persistence**       | Database (survives crashes, hot-reloads, restarts) |
+| **Command prefixes**       | `!standupbot`, `!su`, `@standupbot` (all three) |
+| **Feature scope**          | Full parity — threads, edit-after-send, undo, MSC3464, notifications, E2E |
+| **Encryption migration**   | New bot account — users re-verify once |
+| **Maubot instance**        | Assume recent (not latest) version already available |
+| **Deployment target**      | OpenShift (existing deployment) |
+| **Testing environment**    | None currently — manual testing against live homeserver |
+
+### What changes
+
+Rewrite standupbot from scratch as a Python maubot plugin. The bot runs inside
+a maubot instance rather than as a standalone binary. The entire Go codebase
+is replaced. A new Matrix bot account will be used.
+
+### Maubot architecture
+
+```
+maubot instance (runs on server or container)
+├── Web management UI (plugin upload, config, logs)
+├── Matrix client (handled by maubot, not your code)
+├── E2E encryption (handled by maubot)
+└── Plugins (.mbp files)
+    └── standupbot/
+        ├── maubot.yaml          (plugin metadata)
+        ├── standupbot/
+        │   ├── __init__.py      (plugin entry point)
+        │   ├── bot.py           (Plugin subclass — commands, event routing)
+        │   ├── flow.py          (standup flow state machine & data model)
+        │   ├── post.py          (post formatting & sending)
+        │   ├── scheduler.py     (notification scheduling)
+        │   ├── config.py        (user config via Matrix state events)
+        │   └── db.py            (database models — flow persistence)
+        └── base-config.yaml     (default config)
+```
+
+### What maubot handles for you
+
+- Matrix client lifecycle (login, sync, reconnect)
+- E2E encryption (key management, session sharing)
+- Database connection (asyncpg or aiosqlite — configured at instance level)
+- Event dispatching to handlers
+- Plugin hot-reload (update without restarting)
+- Web UI for configuration and monitoring
+- Multi-bot hosting (one instance, many plugins)
+
+### What you write
+
+Only the bot-specific logic:
+- Command handlers (`@command.new()` decorators)
+- Event handlers (`@event.on()` decorators)
+- Standup flow state machine (persisted to database)
+- Post formatting
+- Notification scheduling (async timers)
+- User config read/write via Matrix room state events
+- Database schema for flow persistence only (user config stays in state events)
+
+### Implementation plan
+
+#### Phase 1: Plugin scaffold and database (1 day)
+
+1. Create plugin directory structure with `maubot.yaml`.
+2. Define database schema for flow persistence (supports both SQLite and
+   PostgreSQL via maubot's database abstraction):
+   - `standup_flow` table: user_id, flow_id (UUID), state (enum), room_id,
+     created_at, updated_at.
+   - `standup_item` table: flow_id, section (done/planned/blockers/notes),
+     event_id, body, formatted_body, position.
+   - `previous_post` table: user_id, event_id, flow_id, day, room_id.
+   - `reactable_event` table: flow_id, event_id (for tracking ✅/❌ targets).
+3. Implement database upgrade mechanism (maubot's built-in upgrade table).
+4. Write `base-config.yaml` with default settings.
+
+Note: User config (timezone, notify time, send room, thread preference) is
+NOT stored in the database. It is read/written from Matrix room state events
+using the existing `com.nevarro.standupbot.*` custom event types, preserving
+compatibility with the current Go bot's stored config.
+
+#### Phase 2: User config via state events (1 day)
+
+Port the state event read/write layer from `store/config_room.go` and
+`types/state_events.go`:
+
+1. Define custom state event content types:
+   - `com.nevarro.standupbot.timezone` → `TzSettingEventContent`
+   - `com.nevarro.standupbot.notify` → `NotifyEventContent`
+   - `com.nevarro.standupbot.send_room` → `SendRoomEventContent`
+   - `com.nevarro.standupbot.use_threads` → `UseThreadsEventContent`
+   - `com.nevarro.standupbot.previous_post` → `PreviousPostEventContent`
+2. Implement in-memory cache (dict per user) populated on startup by scanning
+   joined rooms' state events (port of `standupbot.go` lines 177–226).
+3. Implement cache-through write: update state event + cache on user config
+   changes.
+4. State key = user ID local part (e.g., `alice` from `@alice:example.com`),
+   matching Go bot behavior.
+
+#### Phase 3: Core command handlers (2–3 days)
+
+Port each command from `command_handler.go`:
+
+```python
+from maubot import Plugin
+from maubot.handlers import command
+
+class StandupBot(Plugin):
+    @command.new(name="standupbot", aliases=["su"])
+    async def standup(self, evt) -> None:
+        pass
+
+    @standup.subcommand("new")
+    async def new_post(self, evt) -> None:
+        # Start standup flow
+        ...
+
+    @standup.subcommand("help")
+    async def help(self, evt) -> None:
+        ...
+
+    @standup.subcommand("show")
+    async def show(self, evt) -> None:
+        ...
+
+    @standup.subcommand("edit")
+    async def edit(self, evt) -> None:
+        ...
+
+    @standup.subcommand("cancel")
+    async def cancel(self, evt) -> None:
+        ...
+
+    @standup.subcommand("undo")
+    async def undo(self, evt) -> None:
+        ...
+
+    @standup.subcommand("tz")
+    async def timezone(self, evt) -> None:
+        ...
+
+    @standup.subcommand("notify")
+    async def notify(self, evt) -> None:
+        ...
+
+    @standup.subcommand("room")
+    async def room(self, evt) -> None:
+        ...
+
+    @standup.subcommand("threads")
+    async def threads(self, evt) -> None:
+        ...
+
+    @standup.subcommand("vanquish")
+    async def vanquish(self, evt) -> None:
+        ...
+```
+
+Also register `@standupbot` as an additional trigger (maubot mention handler
+or raw event filter) to maintain the third command prefix.
+
+#### Phase 4: Standup flow state machine (2–3 days)
+
+This is the most complex part — porting the interactive flow from
+`command_handler.go` and `create_post.go`.
+
+1. Port `StandupFlow` struct → Python dataclass with DB-backed persistence.
+   Every state change writes to the database immediately (no JSON-on-shutdown).
+2. Port flow state transitions (Done → Planned → Blockers → Notes → Confirm).
+3. Port message collection: listen for non-command messages during active flow,
+   store items to DB as they arrive.
+4. Port reaction handling: ✅ to advance, ❌ to cancel.
+5. Port thread mode: create thread roots, collect replies via relation events.
+6. Port preview generation and edit-after-send.
+7. Port post formatting (Markdown → HTML via mautrix-python format utils).
+8. Port "on behalf of" posting (MSC3464 `space.nevarro.msc3464.on_behalf_of`
+   custom field in message content).
+
+#### Phase 5: Notification scheduler (1 day)
+
+1. Implement async background task (`asyncio.create_task` in `start()`) that
+   checks notifications each minute.
+2. Port timezone conversion logic (Python `zoneinfo` stdlib module).
+3. Port weekend skipping.
+4. Port duplicate-flow prevention (check DB for active flow before creating).
+5. Cancel task in `stop()` to handle plugin reload cleanly.
+6. On startup, reload notification schedule from state events (same scan as
+   Phase 2).
+
+#### Phase 6: Event handlers for edits and redactions (1 day)
+
+1. Handle `m.room.message` with `m.relates_to` / `m.new_content` (edits) →
+   update item in DB, regenerate preview.
+2. Handle `m.room.redaction` → remove item from DB, update preview.
+3. Handle reactions on non-command messages during active flow.
+4. Handle reactions on preview messages (✅ Send / ❌ Cancel).
+
+#### Phase 7: Invite and room management (0.5 day)
+
+1. Auto-join on invite (port of `standupbot.go` lines 261–273).
+2. Track room membership for encryption key sharing (maubot handles most of
+   this, but verify behavior).
+3. Implement `vanquish` command (bot leaves room).
+
+#### Phase 8: Deployment (1 day)
+
+1. Build `.mbp` plugin package.
+2. Upload to existing maubot instance on OpenShift.
+3. Configure bot client in maubot management UI.
+4. Verify PVC / persistent storage for maubot's database.
+5. Update CI/CD pipeline: build `.mbp` on push, optionally auto-upload.
+
+#### Phase 9: Testing and validation (2–3 days)
+
+Manual testing against live Fedora Matrix homeserver:
+
+1. Test login and encryption (new bot account, users re-verify).
+2. Test full standup flow: `!su new` → add items → ✅ confirm → send to room.
+3. Test thread mode: `!su threads true`, verify thread roots and reply
+   collection.
+4. Test edit-after-send: modify items after posting, ✅ re-send.
+5. Test undo: `!su undo` redacts sent post.
+6. Test all config commands: `!su tz`, `!su notify`, `!su room`, `!su threads`.
+7. Test notification scheduling: set notify time, verify DM arrives.
+8. Test flow persistence: hot-reload plugin mid-flow, verify flow resumes.
+9. Test invite handling: invite bot to new room, verify auto-join.
+10. Test all three command prefixes: `!standupbot new`, `!su new`,
+    `@standupbot new`.
+11. Test reaction-based cancel (❌) at each flow stage.
+12. Test message redaction during flow (delete an item, verify preview updates).
+13. Test edge cases: multiple rapid messages, empty sections, very long items.
+
+### Risks
+
+- **Feature parity gaps:** The interactive flow (reactions, edits, threads,
+  edit-after-send) is intricate. Subtle behaviors may be lost in translation.
+  The Go codebase has ~1050 lines of flow logic across `command_handler.go`
+  and `create_post.go`.
+- **Maubot dependency:** You now depend on the maubot project for the
+  framework, its update cadence, and its compatibility with homeservers.
+- **Maubot version uncertainty:** Assuming "recent but not latest" — some APIs
+  may differ from current docs. May need to pin to a specific version and test.
+- **Python async complexity:** The standup flow is stateful and interactive.
+  Managing concurrent user flows in async Python requires care around shared
+  state, cancellation, and error handling.
+- **No test environment:** All testing against live homeserver increases risk
+  of disruption during development. Consider creating a test room or using a
+  staging homeserver if possible.
+- **E2E encryption:** Maubot handles encryption, but its support may have
+  different behavior or limitations vs. the current direct Olm usage.
+
+### Estimated effort
+
+**10–15 days** of focused development, including testing and deployment.
+
+### What you get
+
+- Modern Python codebase with maubot's plugin ecosystem.
+- No direct Matrix client management (maubot handles login, sync, encryption).
+- Hot-reloadable plugin (update without restarting the bot).
+- Web management UI for configuration and monitoring.
+- Potential to host other Matrix bots on the same instance.
+- Cleaner separation of concerns (framework vs. bot logic).
+- DB-backed flow persistence (more robust than current JSON-on-shutdown).
+- Dual database support (SQLite for dev, PostgreSQL for production).
+
+---
+
+## Comparison
+
+| Dimension                  | Option A: Update mautrix-go | Option B: Rewrite in maubot |
+|----------------------------|-----------------------------|-----------------------------|
+| **Effort**                 | 5–8 days                    | 10–15 days                  |
+| **Risk of regressions**    | Low–Medium                  | Medium–High                 |
+| **Language**               | Go (same)                   | Python (new)                |
+| **Deployment model**       | Standalone binary (same)    | Maubot instance (new)       |
+| **E2E encryption**         | Direct control (goolm)      | Framework-managed           |
+| **C dependencies**         | None (goolm is pure Go)     | None                        |
+| **Feature parity**         | Guaranteed (same code)      | Must be re-validated        |
+| **Future maintenance**     | You maintain Matrix client code | Maubot maintains client code |
+| **Hot reload**             | No (restart required)       | Yes                         |
+| **Multi-bot hosting**      | No                          | Yes                         |
+| **Operational familiarity**| Same as today               | New ops model               |
+
+## Recommendation
+
+**Option A is lower risk and faster** if the primary goal is to unblock
+connectivity to modern Fedora Matrix homeservers. The codebase is only ~2000
+lines of Go — the mechanical changes (context threading, handler signatures)
+are tedious but straightforward, and you retain full feature parity with zero
+translation risk.
+
+**Option B makes sense if** you also want to reduce long-term maintenance
+burden, plan to add more Matrix bots, or prefer Python. But the rewrite cost
+is roughly double, and the stateful interactive flow is the hardest part to
+get right in a new language and framework.

--- a/standupbot-maubot/base-config.yaml
+++ b/standupbot-maubot/base-config.yaml
@@ -1,0 +1,2 @@
+version: "1.0.0"
+source_url: "https://gitlab.com/beeper/standupbot/"

--- a/standupbot-maubot/maubot.yaml
+++ b/standupbot-maubot/maubot.yaml
@@ -1,0 +1,11 @@
+maubot: 0.4.1
+id: com.nevarro.standupbot
+version: 1.0.0
+license: AGPL-3.0-or-later
+modules:
+  - standupbot
+main_class: StandupBot
+database: true
+config: true
+extra_files:
+  - base-config.yaml

--- a/standupbot-maubot/standupbot/__init__.py
+++ b/standupbot-maubot/standupbot/__init__.py
@@ -1,0 +1,1 @@
+from .bot import StandupBot

--- a/standupbot-maubot/standupbot/bot.py
+++ b/standupbot-maubot/standupbot/bot.py
@@ -31,6 +31,8 @@ from .post import (
     edit_preview,
     send_to_send_room,
     go_to_state_and_notify,
+    trim_reply_fallback_text,
+    trim_reply_fallback_html,
 )
 from .scheduler import NotificationScheduler
 
@@ -138,14 +140,16 @@ class StandupBot(Plugin):
         if content.msgtype != MessageType.TEXT:
             return
         body = content.body or ""
-        if body.startswith("!"):
-            return
 
         cmd_text = self._extract_mention_command(body)
         if cmd_text is not None:
             await self._dispatch_mention_command(evt, cmd_text)
-        else:
-            await self._handle_flow_message(evt)
+            return
+
+        if body.startswith("!"):
+            return
+
+        await self._handle_flow_message(evt)
 
     @event.on(EventType.REACTION)
     async def on_reaction(self, evt) -> None:
@@ -202,6 +206,8 @@ class StandupBot(Plugin):
             f"@{localpart}:",
             f"@{localpart}",
             f"{localpart}:",
+            f"!{localpart}:",
+            "!su:",
         ]
         for prefix in prefixes:
             if lower.startswith(prefix.lower()):
@@ -415,6 +421,7 @@ class StandupBot(Plugin):
                 {"msgtype": "m.notice", "body": "No standup post to cancel."},
             )
         else:
+            await flow.delete(self.database, uid)
             self.flows[uid] = new_flow()
             await self.client.send_message_event(
                 evt.room_id,
@@ -609,14 +616,19 @@ class StandupBot(Plugin):
                 {"msgtype": "m.notice", "body": text},
             )
         else:
-            room_id = room_id.strip()
+            parts = room_id.strip().split(None, 1)
+            room_to_join = parts[0]
+            server_name = parts[1] if len(parts) > 1 else None
             try:
-                resp = await self.client.join_room(room_id)
-                joined_room_id = resp.room_id if hasattr(resp, "room_id") else RoomID(room_id)
+                join_args = [room_to_join]
+                if server_name:
+                    join_args.append(server_name)
+                resp = await self.client.join_room(*join_args)
+                joined_room_id = resp.room_id if hasattr(resp, "room_id") else RoomID(room_to_join)
                 await self.user_config.set_send_room(evt.sender, evt.room_id, joined_room_id)
-                text = f"Joined {room_id} and set that as your send room"
+                text = f"Joined {room_to_join} and set that as your send room"
             except Exception as e:
-                text = f"Could not join room {room_id}: {e}"
+                text = f"Could not join room {room_to_join}: {e}"
                 await self.client.send_message_event(
                     evt.room_id,
                     EventType.ROOM_MESSAGE,
@@ -811,7 +823,9 @@ class StandupBot(Plugin):
 
     async def _handle_red_x(self, evt, flow: StandupFlow) -> None:
         if flow.state in (FlowState.CONFIRM, FlowState.SENT):
-            self.flows[str(evt.sender)] = new_flow()
+            uid = str(evt.sender)
+            await flow.delete(self.database, uid)
+            self.flows[uid] = new_flow()
             await self.client.send_message_event(
                 evt.room_id,
                 EventType.ROOM_MESSAGE,
@@ -830,8 +844,8 @@ class StandupBot(Plugin):
         if new_content is None:
             return
 
-        new_body = getattr(new_content, "body", "") or ""
-        new_formatted = getattr(new_content, "formatted_body", "") or ""
+        new_body = trim_reply_fallback_text(getattr(new_content, "body", "") or "")
+        new_formatted = trim_reply_fallback_html(getattr(new_content, "formatted_body", "") or "")
 
         updated = await flow.update_item(edit_event_id, new_body, new_formatted, self.database)
         if updated:
@@ -866,12 +880,10 @@ class StandupBot(Plugin):
         if not reply_to_id:
             return
 
-        body = content.body or ""
-        formatted_body = ""
-        if hasattr(content, "formatted_body"):
-            formatted_body = content.formatted_body or ""
-        elif hasattr(content, "get"):
-            formatted_body = content.get("formatted_body", "")
+        body = trim_reply_fallback_text(content.body or "")
+        formatted_body = trim_reply_fallback_html(
+            getattr(content, "formatted_body", "") or ""
+        )
 
         added = await flow.add_thread_reply(
             str(evt.event_id),

--- a/standupbot-maubot/standupbot/bot.py
+++ b/standupbot-maubot/standupbot/bot.py
@@ -1,0 +1,916 @@
+from __future__ import annotations
+
+import asyncio
+import re
+from typing import Dict, Optional, Type
+from zoneinfo import ZoneInfo
+
+from maubot import Plugin, MessageEvent
+from maubot.handlers import command, event
+from mautrix.types import (
+    EventType,
+    Membership,
+    MessageType,
+    RoomID,
+    UserID,
+    EventID,
+    StateEvent,
+    Format,
+)
+from mautrix.util.config import BaseProxyConfig
+
+from .config import Config
+from .db import upgrade_table
+from .flow import StandupFlow, FlowState, StandupItem, new_flow
+from .state_events import UserConfigCache, STATE_PREVIOUS_POST, state_key
+from .post import (
+    CHECKMARK,
+    RED_X,
+    format_post,
+    show_message_preview,
+    edit_preview,
+    send_to_send_room,
+    go_to_state_and_notify,
+)
+from .scheduler import NotificationScheduler
+
+
+class StandupBot(Plugin):
+    flows: Dict[str, StandupFlow]
+    user_config: UserConfigCache
+    _notify_task: Optional[asyncio.Task]
+
+    async def start(self) -> None:
+        await super().start()
+        self.config.load_and_update()
+        self.flows = {}
+        self.user_config = UserConfigCache(self.client, self.log)
+        loaded = await StandupFlow.load_all(self.database)
+        self.flows = loaded
+        await self.user_config.populate_from_joined_rooms()
+        self._scheduler = NotificationScheduler(
+            client=self.client,
+            log=self.log,
+            user_config=self.user_config,
+            flows=self.flows,
+            start_flow_callback=self._start_new_flow,
+        )
+        self._notify_task = asyncio.create_task(self._scheduler.run())
+
+    async def stop(self) -> None:
+        if self._notify_task is not None:
+            self._notify_task.cancel()
+            try:
+                await self._notify_task
+            except asyncio.CancelledError:
+                pass
+
+    @classmethod
+    def get_config_class(cls) -> Type[BaseProxyConfig]:
+        return Config
+
+    @classmethod
+    def get_db_upgrade_table(cls):
+        return upgrade_table
+
+    # ── Commands ──────────────────────────────────────────────────────
+
+    @command.new(name="standupbot", aliases=("su",), require_subcommand=False)
+    async def cmd(self, evt: MessageEvent) -> None:
+        await self._do_help(evt)
+
+    @cmd.subcommand("new")
+    async def cmd_new(self, evt: MessageEvent) -> None:
+        await self._handle_new(evt)
+
+    @cmd.subcommand("help")
+    async def cmd_help(self, evt: MessageEvent) -> None:
+        await self._do_help(evt)
+
+    @cmd.subcommand("show")
+    async def cmd_show(self, evt: MessageEvent) -> None:
+        await self._handle_show(evt)
+
+    @cmd.subcommand("edit")
+    @command.argument("section", pass_raw=True)
+    async def cmd_edit(self, evt: MessageEvent, section: str) -> None:
+        await self._handle_edit(evt, section)
+
+    @cmd.subcommand("cancel")
+    async def cmd_cancel(self, evt: MessageEvent) -> None:
+        await self._handle_cancel(evt)
+
+    @cmd.subcommand("undo")
+    async def cmd_undo(self, evt: MessageEvent) -> None:
+        await self._handle_undo(evt)
+
+    @cmd.subcommand("tz")
+    @command.argument("timezone", required=False, pass_raw=True)
+    async def cmd_tz(self, evt: MessageEvent, timezone: str) -> None:
+        await self._handle_timezone(evt, timezone if timezone else None)
+
+    @cmd.subcommand("notify")
+    @command.argument("time_spec", required=False, pass_raw=True)
+    async def cmd_notify(self, evt: MessageEvent, time_spec: str) -> None:
+        await self._handle_notify(evt, time_spec if time_spec else None)
+
+    @cmd.subcommand("room")
+    @command.argument("room_id", required=False, pass_raw=True)
+    async def cmd_room(self, evt: MessageEvent, room_id: str) -> None:
+        await self._handle_room(evt, room_id if room_id else None)
+
+    @cmd.subcommand("threads")
+    @command.argument("enabled", required=False, pass_raw=True)
+    async def cmd_threads(self, evt: MessageEvent, enabled: str) -> None:
+        await self._handle_threads(evt, enabled if enabled else None)
+
+    @cmd.subcommand("vanquish")
+    async def cmd_vanquish(self, evt: MessageEvent) -> None:
+        await self.client.leave_room(evt.room_id)
+
+    # ── Event handlers ────────────────────────────────────────────────
+
+    @event.on(EventType.ROOM_MESSAGE)
+    async def on_message(self, evt: MessageEvent) -> None:
+        if evt.sender == self.client.mxid:
+            return
+        content = evt.content
+        if content.msgtype != MessageType.TEXT:
+            return
+        body = content.body or ""
+        if body.startswith("!"):
+            return
+
+        cmd_text = self._extract_mention_command(body)
+        if cmd_text is not None:
+            await self._dispatch_mention_command(evt, cmd_text)
+        else:
+            await self._handle_flow_message(evt)
+
+    @event.on(EventType.REACTION)
+    async def on_reaction(self, evt) -> None:
+        if evt.sender == self.client.mxid:
+            return
+        uid = str(evt.sender)
+        flow = self.flows.get(uid)
+        if not flow or flow.state == FlowState.NOT_STARTED:
+            return
+
+        relates_to = evt.content.relates_to
+        reacted_event_id = str(relates_to.event_id)
+        if reacted_event_id not in flow.reactable_events:
+            return
+
+        await self.client.send_receipt(evt.room_id, evt.event_id)
+
+        key = relates_to.key
+        if key == CHECKMARK:
+            await self._handle_checkmark(evt, flow)
+        elif key == RED_X:
+            await self._handle_red_x(evt, flow)
+
+    @event.on(EventType.ROOM_REDACTION)
+    async def on_redaction(self, evt) -> None:
+        uid = str(evt.sender)
+        flow = self.flows.get(uid)
+        if not flow:
+            return
+
+        redacts = str(evt.redacts)
+        removed = await flow.remove_item_by_event_id(redacts, self.database)
+        if removed and flow.preview_event_id:
+            await edit_preview(
+                self.client, str(evt.room_id), uid, flow,
+            )
+
+    @event.on(EventType.ROOM_MEMBER)
+    async def on_member(self, evt: StateEvent) -> None:
+        if (
+            evt.state_key == str(self.client.mxid)
+            and evt.content.membership == Membership.INVITE
+        ):
+            await self.client.join_room(evt.room_id)
+
+    # ── Mention parsing ──────────────────────────────────────────────
+
+    def _extract_mention_command(self, body: str) -> Optional[str]:
+        localpart = str(self.client.mxid).split(":")[0].lstrip("@")
+        body_stripped = body.strip()
+        lower = body_stripped.lower()
+
+        prefixes = [
+            f"@{localpart}:",
+            f"@{localpart}",
+            f"{localpart}:",
+        ]
+        for prefix in prefixes:
+            if lower.startswith(prefix.lower()):
+                remainder = body_stripped[len(prefix):].strip()
+                return remainder if remainder else "help"
+        return None
+
+    async def _dispatch_mention_command(self, evt: MessageEvent, cmd_text: str) -> None:
+        parts = cmd_text.split(None, 1)
+        cmd_name = parts[0].lower() if parts else "help"
+        args = parts[1] if len(parts) > 1 else ""
+
+        dispatch = {
+            "new": lambda: self._handle_new(evt),
+            "help": lambda: self._do_help(evt),
+            "show": lambda: self._handle_show(evt),
+            "edit": lambda: self._handle_edit(evt, args),
+            "cancel": lambda: self._handle_cancel(evt),
+            "undo": lambda: self._handle_undo(evt),
+            "tz": lambda: self._handle_timezone(evt, args if args else None),
+            "notify": lambda: self._handle_notify(evt, args if args else None),
+            "room": lambda: self._handle_room(evt, args if args else None),
+            "threads": lambda: self._handle_threads(evt, args if args else None),
+            "vanquish": lambda: self.client.leave_room(evt.room_id),
+        }
+
+        handler = dispatch.get(cmd_name, lambda: self._do_help(evt))
+        await handler()
+
+    # ── Flow message handling ─────────────────────────────────────────
+
+    async def _handle_flow_message(self, evt: MessageEvent) -> None:
+        config_room = self.user_config.get_config_room(evt.sender)
+        if config_room != evt.room_id:
+            return
+
+        uid = str(evt.sender)
+        flow = self.flows.get(uid)
+        if not flow:
+            return
+
+        content = evt.content
+        relates_to = content.relates_to
+        if relates_to:
+            rel_type = relates_to.rel_type if hasattr(relates_to, "rel_type") else None
+            if rel_type is None and hasattr(relates_to, "type"):
+                rel_type = relates_to.type
+
+            if rel_type == "m.replace":
+                await self._handle_edit_event(evt, flow)
+                await self.client.send_receipt(evt.room_id, evt.event_id)
+                return
+            elif rel_type in ("m.in_reply_to", "io.element.thread", "m.thread"):
+                await self._handle_reply_event(evt, flow)
+                await self.client.send_receipt(evt.room_id, evt.event_id)
+                return
+
+        if flow.state in (FlowState.DONE, FlowState.PLANNED, FlowState.BLOCKERS, FlowState.NOTES):
+            await flow.add_item(
+                flow.state,
+                str(evt.event_id),
+                content.body or "",
+                getattr(content, "formatted_body", "") or "",
+                self.database,
+            )
+            await self.client.react(evt.room_id, evt.event_id, CHECKMARK)
+            flow.reactable_events.append(str(evt.event_id))
+            await flow.save(self.database, uid)
+            await self.client.send_receipt(evt.room_id, evt.event_id)
+
+    # ── Command implementations ───────────────────────────────────────
+
+    async def _handle_new(self, evt: MessageEvent) -> None:
+        self.user_config.set_config_room(evt.sender, evt.room_id)
+        flow = new_flow()
+        flow.room_id = str(evt.room_id)
+        self.flows[str(evt.sender)] = flow
+
+        use_threads = self.user_config.get_use_threads(evt.sender)
+        next_state = FlowState.THREADS if use_threads else FlowState.DONE
+
+        await go_to_state_and_notify(
+            self.client, str(evt.room_id), str(evt.sender), flow, next_state, self.database,
+        )
+        await self.client.send_receipt(evt.room_id, evt.event_id)
+
+    async def _do_help(self, evt: MessageEvent) -> None:
+        version = self.config.get("version", "unknown")
+        source_url = self.config.get("source_url", "https://gitlab.com/beeper/standupbot/")
+
+        notice_text = (
+            "COMMANDS:\n"
+            "* new -- prepare a new standup post\n"
+            "* show -- show the current standup post\n"
+            "* edit [Done|Planned|Blockers|Notes] -- edit the given section of the standup post\n"
+            "* cancel -- cancel the current standup post\n"
+            "* undo -- undo sending the current standup post to the send room\n"
+            "* help -- show this help\n"
+            "* vanquish -- tell the bot to leave the room\n"
+            "* tz [timezone] -- show or set the timezone to use for configuring notifications\n"
+            "* notify [time]|stop -- show or set the time at which the standup notification will be sent\n"
+            "* room [room alias or ID] -- show or set the room where your standup notification will be sent\n"
+            "* threads [true|false] -- whether or not to use threads for composing standup posts\n"
+            f"\nVersion {version}. Source code: {source_url}"
+        )
+        notice_html = (
+            "<b>COMMANDS:</b>\n<ul>"
+            "<li><b>new</b> &mdash; prepare a new standup post</li>"
+            "<li><b>show</b> &mdash; show the current standup post</li>"
+            "<li><b>edit [Done|Planned|Blockers|Notes]</b> &mdash; edit the given section of the standup post</li>"
+            "<li><b>cancel</b> &mdash; cancel the current standup post</li>"
+            "<li><b>undo</b> &mdash; undo sending the current standup post to the send room</li>"
+            "<li><b>help</b> &mdash; show this help</li>"
+            "<li><b>vanquish</b> &mdash; tell the bot to leave the room</li>"
+            "<li><b>tz [timezone]</b> &mdash; show or set the timezone to use for configuring notifications</li>"
+            "<li><b>notify [time]|stop</b> &mdash; show or set the time at which the standup notification will be sent</li>"
+            "<li><b>room [room alias or ID]</b> &mdash; show or set the room where your standup notification will be sent</li>"
+            "<li><b>threads [true|false]</b> &mdash; whether or not to use threads for composing standup posts</li>"
+            "</ul>\n"
+            f'Version {version}. <a href="{source_url}">Source code</a>.'
+        )
+
+        await self.client.send_message_event(
+            evt.room_id,
+            EventType.ROOM_MESSAGE,
+            {
+                "msgtype": "m.notice",
+                "body": notice_text,
+                "format": "org.matrix.custom.html",
+                "formatted_body": notice_html,
+            },
+        )
+        self.user_config.set_config_room(evt.sender, evt.room_id)
+        await self.client.send_receipt(evt.room_id, evt.event_id)
+
+    async def _handle_show(self, evt: MessageEvent) -> None:
+        uid = str(evt.sender)
+        flow = self.flows.get(uid)
+        if flow and flow.state != FlowState.NOT_STARTED:
+            content = format_post(uid, flow, preview=True, send_confirmation=False, is_edit_of_existing=False)
+            await self.client.send_message_event(evt.room_id, EventType.ROOM_MESSAGE, content)
+        else:
+            await self.client.send_message_event(
+                evt.room_id,
+                EventType.ROOM_MESSAGE,
+                {"msgtype": "m.text", "body": "No standup post to show."},
+            )
+        self.user_config.set_config_room(evt.sender, evt.room_id)
+        await self.client.send_receipt(evt.room_id, evt.event_id)
+
+    async def _handle_edit(self, evt: MessageEvent, section: str) -> None:
+        section = section.strip()
+        if self.user_config.get_use_threads(evt.sender):
+            await self.client.send_message_event(
+                evt.room_id,
+                EventType.ROOM_MESSAGE,
+                {
+                    "msgtype": "m.notice",
+                    "body": "You cannot use !edit when using threads. Just reply to the corresponding thread.",
+                },
+            )
+            self.user_config.set_config_room(evt.sender, evt.room_id)
+            await self.client.send_receipt(evt.room_id, evt.event_id)
+            return
+
+        section_map = {
+            "done": FlowState.DONE,
+            "planned": FlowState.PLANNED,
+            "blockers": FlowState.BLOCKERS,
+            "notes": FlowState.NOTES,
+        }
+        target = section_map.get(section.lower())
+        if target is None:
+            await self.client.send_message_event(
+                evt.room_id,
+                EventType.ROOM_MESSAGE,
+                {
+                    "msgtype": "m.notice",
+                    "body": "Invalid item to edit! Must be one of Done, Planned, Blockers, or Notes",
+                },
+            )
+            self.user_config.set_config_room(evt.sender, evt.room_id)
+            await self.client.send_receipt(evt.room_id, evt.event_id)
+            return
+
+        uid = str(evt.sender)
+        flow = self.flows.get(uid)
+        if not flow or flow.state == FlowState.NOT_STARTED:
+            await self.client.send_message_event(
+                evt.room_id,
+                EventType.ROOM_MESSAGE,
+                {"msgtype": "m.notice", "body": "No standup post to edit."},
+            )
+            self.user_config.set_config_room(evt.sender, evt.room_id)
+            await self.client.send_receipt(evt.room_id, evt.event_id)
+            return
+
+        await go_to_state_and_notify(
+            self.client, str(evt.room_id), uid, flow, target, self.database,
+        )
+        self.user_config.set_config_room(evt.sender, evt.room_id)
+        await self.client.send_receipt(evt.room_id, evt.event_id)
+
+    async def _handle_cancel(self, evt: MessageEvent) -> None:
+        uid = str(evt.sender)
+        flow = self.flows.get(uid)
+        if not flow or flow.state == FlowState.NOT_STARTED:
+            await self.client.send_message_event(
+                evt.room_id,
+                EventType.ROOM_MESSAGE,
+                {"msgtype": "m.notice", "body": "No standup post to cancel."},
+            )
+        else:
+            self.flows[uid] = new_flow()
+            await self.client.send_message_event(
+                evt.room_id,
+                EventType.ROOM_MESSAGE,
+                {"msgtype": "m.notice", "body": "Standup post cancelled"},
+            )
+        self.user_config.set_config_room(evt.sender, evt.room_id)
+        await self.client.send_receipt(evt.room_id, evt.event_id)
+
+    async def _handle_undo(self, evt: MessageEvent) -> None:
+        uid = str(evt.sender)
+        flow = self.flows.get(uid)
+        if not flow or flow.state != FlowState.SENT:
+            await self.client.send_message_event(
+                evt.room_id,
+                EventType.ROOM_MESSAGE,
+                {"msgtype": "m.notice", "body": "No sent standup post to undo."},
+            )
+            self.user_config.set_config_room(evt.sender, evt.room_id)
+            await self.client.send_receipt(evt.room_id, evt.event_id)
+            return
+
+        send_room = self.user_config.get_send_room(evt.sender)
+        if not send_room:
+            await self.client.send_message_event(
+                evt.room_id,
+                EventType.ROOM_MESSAGE,
+                {"msgtype": "m.notice", "body": "No send room configured. Can't undo anything."},
+            )
+            self.user_config.set_config_room(evt.sender, evt.room_id)
+            await self.client.send_receipt(evt.room_id, evt.event_id)
+            return
+
+        sk = state_key(str(evt.sender))
+        try:
+            previous_post = await self.client.get_state_event(evt.room_id, STATE_PREVIOUS_POST, sk)
+        except Exception:
+            await self.client.send_message_event(
+                evt.room_id,
+                EventType.ROOM_MESSAGE,
+                {"msgtype": "m.notice", "body": "No previous standup post to undo."},
+            )
+            self.user_config.set_config_room(evt.sender, evt.room_id)
+            await self.client.send_receipt(evt.room_id, evt.event_id)
+            return
+
+        edit_event_id = previous_post.get("EditEventID", "")
+        try:
+            await self.client.redact(send_room, EventID(edit_event_id))
+            await self.client.send_message_event(
+                evt.room_id,
+                EventType.ROOM_MESSAGE,
+                {
+                    "msgtype": "m.text",
+                    "body": f"Redacted standup post with ID: {edit_event_id} in {evt.room_id}",
+                },
+            )
+            flow.state = FlowState.CONFIRM
+            await flow.save(self.database, uid)
+            await self.client.send_state_event(evt.room_id, STATE_PREVIOUS_POST, {}, state_key=sk)
+        except Exception:
+            await self.client.send_message_event(
+                evt.room_id,
+                EventType.ROOM_MESSAGE,
+                {"msgtype": "m.text", "body": "Failed to redact the standup post!"},
+            )
+
+        self.user_config.set_config_room(evt.sender, evt.room_id)
+        await self.client.send_receipt(evt.room_id, evt.event_id)
+
+    async def _handle_timezone(self, evt: MessageEvent, tz: Optional[str]) -> None:
+        if not tz:
+            user_tz = self.user_config.get_timezone(evt.sender)
+            tz_str = str(user_tz) if user_tz else "not set"
+            await self.client.send_message_event(
+                evt.room_id,
+                EventType.ROOM_MESSAGE,
+                {"msgtype": "m.notice", "body": f"Timezone is set to {tz_str}"},
+            )
+        else:
+            tz = tz.strip()
+            try:
+                location = ZoneInfo(tz)
+            except (KeyError, Exception):
+                await self.client.send_message_event(
+                    evt.room_id,
+                    EventType.ROOM_MESSAGE,
+                    {
+                        "msgtype": "m.notice",
+                        "body": f"{tz} is not a recognized timezone. Use the name corresponding to a file in the IANA Time Zone database, such as 'America/New_York'",
+                    },
+                )
+                self.user_config.set_config_room(evt.sender, evt.room_id)
+                await self.client.send_receipt(evt.room_id, evt.event_id)
+                return
+
+            try:
+                await self.user_config.set_timezone(evt.sender, evt.room_id, str(location))
+                await self.client.send_message_event(
+                    evt.room_id,
+                    EventType.ROOM_MESSAGE,
+                    {"msgtype": "m.notice", "body": f"Timezone set to {location}"},
+                )
+            except Exception as e:
+                await self.client.send_message_event(
+                    evt.room_id,
+                    EventType.ROOM_MESSAGE,
+                    {
+                        "msgtype": "m.notice",
+                        "body": f"Failed setting timezone: {e}\nCheck to make sure that standupbot is a mod/admin in the room!",
+                    },
+                )
+
+        self.user_config.set_config_room(evt.sender, evt.room_id)
+        await self.client.send_receipt(evt.room_id, evt.event_id)
+
+    async def _handle_notify(self, evt: MessageEvent, time_spec: Optional[str]) -> None:
+        if not time_spec:
+            minutes = self.user_config.get_notify_minutes(evt.sender)
+            if minutes is None:
+                text = "Notification time is not set"
+            else:
+                h = minutes // 60
+                m = minutes % 60
+                text = f"Notification time is set to {h:02d}:{m:02d}"
+            await self.client.send_message_event(
+                evt.room_id,
+                EventType.ROOM_MESSAGE,
+                {"msgtype": "m.notice", "body": text},
+            )
+        elif time_spec.strip().lower() == "stop":
+            try:
+                await self.user_config.clear_notify(evt.sender, evt.room_id)
+                text = "Notifications successfully disabled"
+            except Exception:
+                text = "Failed to disable notifications"
+            await self.client.send_message_event(
+                evt.room_id,
+                EventType.ROOM_MESSAGE,
+                {"msgtype": "m.notice", "body": text},
+            )
+        else:
+            time_spec = time_spec.strip()
+            match = re.match(r"(\d\d?):?(\d\d)", time_spec)
+            if not match:
+                await self.client.send_message_event(
+                    evt.room_id,
+                    EventType.ROOM_MESSAGE,
+                    {
+                        "msgtype": "m.notice",
+                        "body": f"{time_spec} is not a valid time. Please specify it in 24-hour time like: 13:30.",
+                    },
+                )
+            else:
+                hours = int(match.group(1))
+                minutes = int(match.group(2))
+                if hours < 0 or hours > 23 or minutes < 0 or minutes > 59:
+                    await self.client.send_message_event(
+                        evt.room_id,
+                        EventType.ROOM_MESSAGE,
+                        {
+                            "msgtype": "m.notice",
+                            "body": f"{time_spec} is not a valid time. Please specify it in 24-hour time like: 13:30.",
+                        },
+                    )
+                else:
+                    minutes_after_midnight = hours * 60 + minutes
+                    try:
+                        await self.user_config.set_notify(evt.sender, evt.room_id, minutes_after_midnight)
+                        text = f"Notification time set to {hours:02d}:{minutes:02d}"
+                    except Exception as e:
+                        text = f"Failed setting notification time: {e}\nCheck to make sure that standupbot is a mod/admin in the room!"
+                    await self.client.send_message_event(
+                        evt.room_id,
+                        EventType.ROOM_MESSAGE,
+                        {"msgtype": "m.notice", "body": text},
+                    )
+
+        self.user_config.set_config_room(evt.sender, evt.room_id)
+        await self.client.send_receipt(evt.room_id, evt.event_id)
+
+    async def _handle_room(self, evt: MessageEvent, room_id: Optional[str]) -> None:
+        if not room_id:
+            send_room = self.user_config.get_send_room(evt.sender)
+            if send_room:
+                text = f"Send room is set to {send_room}"
+            else:
+                text = "Send room not set"
+            await self.client.send_message_event(
+                evt.room_id,
+                EventType.ROOM_MESSAGE,
+                {"msgtype": "m.notice", "body": text},
+            )
+        else:
+            room_id = room_id.strip()
+            try:
+                resp = await self.client.join_room(room_id)
+                joined_room_id = resp.room_id if hasattr(resp, "room_id") else RoomID(room_id)
+                await self.user_config.set_send_room(evt.sender, evt.room_id, joined_room_id)
+                text = f"Joined {room_id} and set that as your send room"
+            except Exception as e:
+                text = f"Could not join room {room_id}: {e}"
+                await self.client.send_message_event(
+                    evt.room_id,
+                    EventType.ROOM_MESSAGE,
+                    {"msgtype": "m.notice", "body": text},
+                )
+                self.user_config.set_config_room(evt.sender, evt.room_id)
+                await self.client.send_receipt(evt.room_id, evt.event_id)
+                return
+
+            await self.client.send_message_event(
+                evt.room_id,
+                EventType.ROOM_MESSAGE,
+                {"msgtype": "m.notice", "body": text},
+            )
+
+            uid = str(evt.sender)
+            flow = self.flows.get(uid)
+            if flow and flow.state == FlowState.CONFIRM:
+                try:
+                    await self.client.redact(evt.room_id, EventID(flow.preview_event_id))
+                except Exception:
+                    pass
+                await show_message_preview(
+                    self.client, str(evt.room_id), uid, flow, False,
+                )
+                await flow.save(self.database, uid)
+
+        self.user_config.set_config_room(evt.sender, evt.room_id)
+        await self.client.send_receipt(evt.room_id, evt.event_id)
+
+    async def _handle_threads(self, evt: MessageEvent, enabled: Optional[str]) -> None:
+        if not enabled:
+            use_threads = self.user_config.get_use_threads(evt.sender)
+            if use_threads:
+                text = "Using threads is enabled."
+            else:
+                text = "Using threads is not enabled."
+            await self.client.send_message_event(
+                evt.room_id,
+                EventType.ROOM_MESSAGE,
+                {"msgtype": "m.notice", "body": text},
+            )
+        else:
+            enabled = enabled.strip().lower()
+            if enabled == "true":
+                value = True
+            elif enabled == "false":
+                value = False
+            else:
+                await self.client.send_message_event(
+                    evt.room_id,
+                    EventType.ROOM_MESSAGE,
+                    {
+                        "msgtype": "m.notice",
+                        "body": f"Failed setting use threads option: {enabled} is not valid. Use 'true' or 'false'.",
+                    },
+                )
+                self.user_config.set_config_room(evt.sender, evt.room_id)
+                await self.client.send_receipt(evt.room_id, evt.event_id)
+                return
+
+            try:
+                await self.user_config.set_use_threads(evt.sender, evt.room_id, value)
+                text = f"Set use threads option to {str(value).lower()}"
+            except Exception as e:
+                text = f"Failed setting use threads option: {e}"
+            await self.client.send_message_event(
+                evt.room_id,
+                EventType.ROOM_MESSAGE,
+                {"msgtype": "m.notice", "body": text},
+            )
+
+        self.user_config.set_config_room(evt.sender, evt.room_id)
+        await self.client.send_receipt(evt.room_id, evt.event_id)
+
+    # ── Reaction handling ─────────────────────────────────────────────
+
+    async def _handle_checkmark(self, evt, flow: StandupFlow) -> None:
+        uid = str(evt.sender)
+        flow.reactable_events = []
+
+        sk = state_key(uid)
+        previous_post = None
+        try:
+            previous_post = await self.client.get_state_event(evt.room_id, STATE_PREVIOUS_POST, sk)
+            if not previous_post or not previous_post.get("FlowID"):
+                previous_post = None
+        except Exception:
+            previous_post = None
+
+        if previous_post and flow.flow_id == previous_post.get("FlowID", ""):
+            if flow.state != FlowState.SENT:
+                try:
+                    await self.client.redact(evt.room_id, EventID(flow.preview_event_id))
+                except Exception:
+                    pass
+                await show_message_preview(
+                    self.client, str(evt.room_id), uid, flow, False,
+                )
+                flow.state = FlowState.SENT
+                await flow.save(self.database, uid)
+                return
+        elif flow.preview_event_id:
+            if flow.state not in (FlowState.CONFIRM, FlowState.SENT, FlowState.THREADS):
+                try:
+                    await self.client.redact(evt.room_id, EventID(flow.preview_event_id))
+                except Exception:
+                    pass
+                flow.state = FlowState.NOTES
+
+        if flow.state == FlowState.DONE:
+            await go_to_state_and_notify(
+                self.client, str(evt.room_id), uid, flow, FlowState.PLANNED, self.database,
+            )
+        elif flow.state == FlowState.PLANNED:
+            await go_to_state_and_notify(
+                self.client, str(evt.room_id), uid, flow, FlowState.BLOCKERS, self.database,
+            )
+        elif flow.state == FlowState.BLOCKERS:
+            await go_to_state_and_notify(
+                self.client, str(evt.room_id), uid, flow, FlowState.NOTES, self.database,
+            )
+        elif flow.state == FlowState.NOTES:
+            await show_message_preview(
+                self.client, str(evt.room_id), uid, flow, False,
+            )
+            flow.state = FlowState.CONFIRM
+            await flow.save(self.database, uid)
+        elif flow.state in (FlowState.THREADS, FlowState.CONFIRM):
+            sent_event_id = await send_to_send_room(
+                self.client, self.user_config, str(evt.room_id), uid, flow,
+            )
+            if sent_event_id:
+                sk = state_key(uid)
+                await self.client.send_state_event(
+                    evt.room_id,
+                    STATE_PREVIOUS_POST,
+                    {
+                        "EditEventID": sent_event_id,
+                        "FlowID": flow.flow_id,
+                        "Day": self.user_config.get_current_weekday_in_user_timezone(uid),
+                        "PlannedItems": [
+                            {
+                                "EventID": i.event_id,
+                                "Body": i.body,
+                                "FormattedBody": i.formatted_body,
+                            }
+                            for i in flow.planned
+                        ],
+                    },
+                    state_key=sk,
+                )
+            await flow.save(self.database, uid)
+        elif flow.state == FlowState.SENT:
+            if not previous_post:
+                await self.client.send_message_event(
+                    evt.room_id,
+                    EventType.ROOM_MESSAGE,
+                    {"msgtype": "m.text", "body": "No previous post info found!"},
+                )
+                self.flows[uid] = new_flow()
+                return
+            sent_event_id = await send_to_send_room(
+                self.client,
+                self.user_config,
+                str(evt.room_id),
+                uid,
+                flow,
+                edit_event_id=previous_post.get("EditEventID"),
+            )
+            if sent_event_id:
+                sk = state_key(uid)
+                await self.client.send_state_event(
+                    evt.room_id,
+                    STATE_PREVIOUS_POST,
+                    {
+                        "EditEventID": sent_event_id,
+                        "FlowID": flow.flow_id,
+                        "Day": self.user_config.get_current_weekday_in_user_timezone(uid),
+                        "PlannedItems": [
+                            {
+                                "EventID": i.event_id,
+                                "Body": i.body,
+                                "FormattedBody": i.formatted_body,
+                            }
+                            for i in flow.planned
+                        ],
+                    },
+                    state_key=sk,
+                )
+            await flow.save(self.database, uid)
+
+    async def _handle_red_x(self, evt, flow: StandupFlow) -> None:
+        if flow.state in (FlowState.CONFIRM, FlowState.SENT):
+            self.flows[str(evt.sender)] = new_flow()
+            await self.client.send_message_event(
+                evt.room_id,
+                EventType.ROOM_MESSAGE,
+                {"msgtype": "m.notice", "body": "Standup post cancelled"},
+            )
+
+    # ── Edit / reply event handling ───────────────────────────────────
+
+    async def _handle_edit_event(self, evt: MessageEvent, flow: StandupFlow) -> None:
+        uid = str(evt.sender)
+        content = evt.content
+        relates_to = content.relates_to
+        edit_event_id = str(relates_to.event_id)
+
+        new_content = getattr(content, "new_content", None)
+        if new_content is None:
+            return
+
+        new_body = getattr(new_content, "body", "") or ""
+        new_formatted = getattr(new_content, "formatted_body", "") or ""
+
+        updated = await flow.update_item(edit_event_id, new_body, new_formatted, self.database)
+        if updated:
+            if flow.state == FlowState.THREADS:
+                await edit_preview(self.client, str(evt.room_id), uid, flow)
+            elif flow.state == FlowState.CONFIRM:
+                await edit_preview(self.client, str(evt.room_id), uid, flow)
+            elif flow.state == FlowState.SENT:
+                try:
+                    await self.client.redact(evt.room_id, EventID(flow.preview_event_id))
+                except Exception:
+                    pass
+                await show_message_preview(
+                    self.client, str(evt.room_id), uid, flow, True,
+                )
+                await flow.save(self.database, uid)
+
+    async def _handle_reply_event(self, evt: MessageEvent, flow: StandupFlow) -> None:
+        if flow.state not in (FlowState.THREADS, FlowState.CONFIRM, FlowState.SENT):
+            return
+
+        uid = str(evt.sender)
+        content = evt.content
+        relates_to = content.relates_to
+
+        reply_to_id = None
+        if hasattr(relates_to, "event_id") and relates_to.event_id:
+            reply_to_id = str(relates_to.event_id)
+        elif hasattr(relates_to, "in_reply_to") and relates_to.in_reply_to:
+            reply_to_id = str(relates_to.in_reply_to.event_id) if hasattr(relates_to.in_reply_to, "event_id") else str(relates_to.in_reply_to)
+
+        if not reply_to_id:
+            return
+
+        body = content.body or ""
+        formatted_body = ""
+        if hasattr(content, "formatted_body"):
+            formatted_body = content.formatted_body or ""
+        elif hasattr(content, "get"):
+            formatted_body = content.get("formatted_body", "")
+
+        added = await flow.add_thread_reply(
+            str(evt.event_id),
+            reply_to_id,
+            body,
+            formatted_body,
+            self.database,
+        )
+
+        if added:
+            await edit_preview(self.client, str(evt.room_id), uid, flow)
+
+            if flow.state == FlowState.SENT and not flow.resend_event_id:
+                resp = await self.client.send_message_event(
+                    evt.room_id,
+                    EventType.ROOM_MESSAGE,
+                    {
+                        "msgtype": "m.text",
+                        "body": f"Send Edit ({CHECKMARK}) or Cancel ({RED_X})?",
+                        "format": "org.matrix.custom.html",
+                        "formatted_body": f"Send Edit ({CHECKMARK}) or Cancel ({RED_X})?",
+                    },
+                )
+                await self.client.react(evt.room_id, resp.event_id, CHECKMARK)
+                await self.client.react(evt.room_id, resp.event_id, RED_X)
+                flow.reactable_events.append(resp.event_id)
+                flow.resend_event_id = resp.event_id
+                await flow.save(self.database, uid)
+
+    # ── Scheduler callback ────────────────────────────────────────────
+
+    async def _start_new_flow(self, room_id: str, user_id: str) -> None:
+        flow = new_flow()
+        flow.room_id = room_id
+        self.flows[user_id] = flow
+
+        use_threads = self.user_config.get_use_threads(UserID(user_id))
+        next_state = FlowState.THREADS if use_threads else FlowState.DONE
+
+        await go_to_state_and_notify(
+            self.client, room_id, user_id, flow, next_state, self.database,
+        )

--- a/standupbot-maubot/standupbot/config.py
+++ b/standupbot-maubot/standupbot/config.py
@@ -1,0 +1,7 @@
+from mautrix.util.config import BaseProxyConfig, ConfigUpdateHelper
+
+
+class Config(BaseProxyConfig):
+    def do_update(self, helper: ConfigUpdateHelper) -> None:
+        helper.copy("version")
+        helper.copy("source_url")

--- a/standupbot-maubot/standupbot/db.py
+++ b/standupbot-maubot/standupbot/db.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from mautrix.util.async_db import Connection, Scheme, UpgradeTable
+
+upgrade_table = UpgradeTable()
+
+
+@upgrade_table.register(description="Initial schema")
+async def upgrade_v1(conn: Connection, scheme: Scheme) -> None:
+    if scheme == Scheme.SQLITE:
+        id_col = "id INTEGER PRIMARY KEY AUTOINCREMENT"
+    else:
+        id_col = "id SERIAL PRIMARY KEY"
+
+    await conn.execute(
+        """CREATE TABLE IF NOT EXISTS standup_flow (
+            user_id          TEXT NOT NULL,
+            flow_id          TEXT NOT NULL,
+            state            INTEGER NOT NULL,
+            room_id          TEXT NOT NULL,
+            preview_event_id TEXT,
+            resend_event_id  TEXT,
+            created_at       TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at       TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (user_id)
+        )"""
+    )
+
+    await conn.execute(
+        f"""CREATE TABLE IF NOT EXISTS standup_item (
+            {id_col},
+            flow_id        TEXT NOT NULL,
+            section        TEXT NOT NULL,
+            event_id       TEXT NOT NULL,
+            body           TEXT NOT NULL,
+            formatted_body TEXT NOT NULL DEFAULT '',
+            position       INTEGER NOT NULL
+        )"""
+    )
+
+    await conn.execute(
+        """CREATE TABLE IF NOT EXISTS reactable_event (
+            flow_id  TEXT NOT NULL,
+            event_id TEXT NOT NULL,
+            PRIMARY KEY (flow_id, event_id)
+        )"""
+    )
+
+    await conn.execute(
+        """CREATE TABLE IF NOT EXISTS thread_event (
+            flow_id  TEXT NOT NULL,
+            section  TEXT NOT NULL,
+            event_id TEXT NOT NULL,
+            PRIMARY KEY (flow_id, section, event_id)
+        )"""
+    )
+
+
+async def save_flow(
+    db,
+    user_id: str,
+    flow_id: str,
+    state: int,
+    room_id: str,
+    preview_event_id: Optional[str],
+    resend_event_id: Optional[str],
+) -> None:
+    await db.execute(
+        """INSERT INTO standup_flow (user_id, flow_id, state, room_id, preview_event_id,
+               resend_event_id, created_at, updated_at)
+           VALUES ($1, $2, $3, $4, $5, $6, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+           ON CONFLICT (user_id) DO UPDATE SET
+               flow_id = $2,
+               state = $3,
+               room_id = $4,
+               preview_event_id = $5,
+               resend_event_id = $6,
+               updated_at = CURRENT_TIMESTAMP""",
+        user_id,
+        flow_id,
+        state,
+        room_id,
+        preview_event_id,
+        resend_event_id,
+    )
+
+
+async def load_flow(db, user_id: str):
+    return await db.fetchrow(
+        "SELECT user_id, flow_id, state, room_id, preview_event_id, resend_event_id,"
+        " created_at, updated_at FROM standup_flow WHERE user_id = $1",
+        user_id,
+    )
+
+
+async def delete_flow(db, user_id: str) -> None:
+    row = await db.fetchrow(
+        "SELECT flow_id FROM standup_flow WHERE user_id = $1", user_id
+    )
+    if row:
+        flow_id = row["flow_id"]
+        await db.execute("DELETE FROM standup_item WHERE flow_id = $1", flow_id)
+        await db.execute("DELETE FROM reactable_event WHERE flow_id = $1", flow_id)
+        await db.execute("DELETE FROM thread_event WHERE flow_id = $1", flow_id)
+    await db.execute("DELETE FROM standup_flow WHERE user_id = $1", user_id)
+
+
+async def save_item(
+    db,
+    flow_id: str,
+    section: str,
+    event_id: str,
+    body: str,
+    formatted_body: str,
+    position: int,
+) -> None:
+    await db.execute(
+        """INSERT INTO standup_item (flow_id, section, event_id, body, formatted_body, position)
+           VALUES ($1, $2, $3, $4, $5, $6)""",
+        flow_id,
+        section,
+        event_id,
+        body,
+        formatted_body,
+        position,
+    )
+
+
+async def load_items(db, flow_id: str, section: str) -> list:
+    return await db.fetch(
+        "SELECT * FROM standup_item WHERE flow_id = $1 AND section = $2 ORDER BY position",
+        flow_id,
+        section,
+    )
+
+
+async def load_all_items(db, flow_id: str) -> list:
+    return await db.fetch(
+        "SELECT * FROM standup_item WHERE flow_id = $1 ORDER BY section, position",
+        flow_id,
+    )
+
+
+async def update_item(db, flow_id: str, event_id: str, body: str, formatted_body: str) -> None:
+    await db.execute(
+        "UPDATE standup_item SET body = $1, formatted_body = $2"
+        " WHERE flow_id = $3 AND event_id = $4",
+        body,
+        formatted_body,
+        flow_id,
+        event_id,
+    )
+
+
+async def remove_item(db, flow_id: str, event_id: str) -> bool:
+    result = await db.execute(
+        "DELETE FROM standup_item WHERE flow_id = $1 AND event_id = $2",
+        flow_id,
+        event_id,
+    )
+    # maubot's execute returns the status string; "DELETE N" where N is rows affected
+    if isinstance(result, str):
+        return not result.endswith("0")
+    return bool(result)
+
+
+async def save_reactable_events(db, flow_id: str, event_ids: List[str]) -> None:
+    await db.execute("DELETE FROM reactable_event WHERE flow_id = $1", flow_id)
+    for eid in event_ids:
+        await db.execute(
+            "INSERT INTO reactable_event (flow_id, event_id) VALUES ($1, $2)",
+            flow_id,
+            eid,
+        )
+
+
+async def load_reactable_events(db, flow_id: str) -> List[str]:
+    rows = await db.fetch(
+        "SELECT event_id FROM reactable_event WHERE flow_id = $1", flow_id
+    )
+    return [row["event_id"] for row in rows]
+
+
+async def save_thread_events(db, flow_id: str, section: str, event_ids: List[str]) -> None:
+    await db.execute(
+        "DELETE FROM thread_event WHERE flow_id = $1 AND section = $2",
+        flow_id,
+        section,
+    )
+    for eid in event_ids:
+        await db.execute(
+            "INSERT INTO thread_event (flow_id, section, event_id) VALUES ($1, $2, $3)",
+            flow_id,
+            section,
+            eid,
+        )
+
+
+async def load_thread_events(db, flow_id: str, section: str) -> List[str]:
+    rows = await db.fetch(
+        "SELECT event_id FROM thread_event WHERE flow_id = $1 AND section = $2",
+        flow_id,
+        section,
+    )
+    return [row["event_id"] for row in rows]
+
+
+async def load_all_flows(db) -> list:
+    return await db.fetch(
+        "SELECT user_id, flow_id, state, room_id, preview_event_id, resend_event_id,"
+        " created_at, updated_at FROM standup_flow"
+    )

--- a/standupbot-maubot/standupbot/flow.py
+++ b/standupbot-maubot/standupbot/flow.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from enum import IntEnum
+from typing import Dict, List, Optional
+
+from . import db as db_module
+
+
+class FlowState(IntEnum):
+    NOT_STARTED = 0
+    DONE = 1
+    PLANNED = 2
+    BLOCKERS = 3
+    NOTES = 4
+    CONFIRM = 5
+    SENT = 6
+    THREADS = 7
+
+
+SECTION_NAMES = {
+    FlowState.DONE: "done",
+    FlowState.PLANNED: "planned",
+    FlowState.BLOCKERS: "blockers",
+    FlowState.NOTES: "notes",
+}
+
+
+@dataclass
+class StandupItem:
+    event_id: str
+    body: str
+    formatted_body: str = ""
+
+
+@dataclass
+class StandupFlow:
+    flow_id: str
+    state: FlowState = FlowState.NOT_STARTED
+    room_id: str = ""
+    reactable_events: List[str] = field(default_factory=list)
+    preview_event_id: Optional[str] = None
+    resend_event_id: Optional[str] = None
+
+    done: List[StandupItem] = field(default_factory=list)
+    planned: List[StandupItem] = field(default_factory=list)
+    blockers: List[StandupItem] = field(default_factory=list)
+    notes: List[StandupItem] = field(default_factory=list)
+
+    done_thread_events: List[str] = field(default_factory=list)
+    planned_thread_events: List[str] = field(default_factory=list)
+    blockers_thread_events: List[str] = field(default_factory=list)
+    notes_thread_events: List[str] = field(default_factory=list)
+
+    def get_section_list(self, state: FlowState) -> List[StandupItem]:
+        return {
+            FlowState.DONE: self.done,
+            FlowState.PLANNED: self.planned,
+            FlowState.BLOCKERS: self.blockers,
+            FlowState.NOTES: self.notes,
+        }[state]
+
+    def get_thread_events(self, state: FlowState) -> List[str]:
+        return {
+            FlowState.DONE: self.done_thread_events,
+            FlowState.PLANNED: self.planned_thread_events,
+            FlowState.BLOCKERS: self.blockers_thread_events,
+            FlowState.NOTES: self.notes_thread_events,
+        }[state]
+
+    async def add_item(
+        self,
+        section: FlowState,
+        event_id: str,
+        body: str,
+        formatted_body: str,
+        db,
+    ) -> None:
+        items = self.get_section_list(section)
+        items.append(StandupItem(event_id=event_id, body=body, formatted_body=formatted_body))
+        position = len(items) - 1
+        await db_module.save_item(
+            db, self.flow_id, SECTION_NAMES[section], event_id, body, formatted_body, position
+        )
+
+    async def remove_item_by_event_id(self, event_id: str, db) -> bool:
+        for section_list in (self.done, self.planned, self.blockers, self.notes):
+            for i, item in enumerate(section_list):
+                if item.event_id == event_id:
+                    section_list.pop(i)
+                    await db_module.remove_item(db, self.flow_id, event_id)
+                    return True
+        return False
+
+    async def update_item(self, event_id: str, body: str, formatted_body: str, db) -> bool:
+        for section_list in (self.done, self.planned, self.blockers, self.notes):
+            for item in section_list:
+                if item.event_id == event_id:
+                    item.body = body
+                    item.formatted_body = formatted_body
+                    await db_module.update_item(db, self.flow_id, event_id, body, formatted_body)
+                    return True
+        return False
+
+    async def add_thread_reply(
+        self,
+        event_id: str,
+        reply_to_event_id: str,
+        body: str,
+        formatted_body: str,
+        db,
+    ) -> bool:
+        for state in (FlowState.DONE, FlowState.PLANNED, FlowState.BLOCKERS, FlowState.NOTES):
+            thread_events = self.get_thread_events(state)
+            if reply_to_event_id in thread_events:
+                section_list = self.get_section_list(state)
+                section_list.append(
+                    StandupItem(event_id=event_id, body=body, formatted_body=formatted_body)
+                )
+                position = len(section_list) - 1
+                section_name = SECTION_NAMES[state]
+                await db_module.save_item(
+                    db, self.flow_id, section_name, event_id, body, formatted_body, position
+                )
+                thread_events.append(event_id)
+                await db_module.save_thread_events(db, self.flow_id, section_name, thread_events)
+                return True
+        return False
+
+    async def save(self, db, user_id: str) -> None:
+        await db_module.save_flow(
+            db,
+            user_id,
+            self.flow_id,
+            int(self.state),
+            self.room_id,
+            self.preview_event_id,
+            self.resend_event_id,
+        )
+        await db_module.save_reactable_events(db, self.flow_id, self.reactable_events)
+        for state in (FlowState.DONE, FlowState.PLANNED, FlowState.BLOCKERS, FlowState.NOTES):
+            section_name = SECTION_NAMES[state]
+            await db_module.save_thread_events(
+                db, self.flow_id, section_name, self.get_thread_events(state)
+            )
+
+    async def delete(self, db, user_id: str) -> None:
+        await db_module.delete_flow(db, user_id)
+
+    @classmethod
+    async def load_all(cls, db) -> Dict[str, StandupFlow]:
+        rows = await db_module.load_all_flows(db)
+        flows: Dict[str, StandupFlow] = {}
+
+        for row in rows:
+            flow = cls(
+                flow_id=row["flow_id"],
+                state=FlowState(row["state"]),
+                room_id=row["room_id"],
+                preview_event_id=row["preview_event_id"],
+                resend_event_id=row["resend_event_id"],
+            )
+
+            items = await db_module.load_all_items(db, flow.flow_id)
+            for item_row in items:
+                si = StandupItem(
+                    event_id=item_row["event_id"],
+                    body=item_row["body"],
+                    formatted_body=item_row["formatted_body"],
+                )
+                section = item_row["section"]
+                if section == "done":
+                    flow.done.append(si)
+                elif section == "planned":
+                    flow.planned.append(si)
+                elif section == "blockers":
+                    flow.blockers.append(si)
+                elif section == "notes":
+                    flow.notes.append(si)
+
+            flow.reactable_events = await db_module.load_reactable_events(db, flow.flow_id)
+
+            for state in (FlowState.DONE, FlowState.PLANNED, FlowState.BLOCKERS, FlowState.NOTES):
+                section_name = SECTION_NAMES[state]
+                evts = await db_module.load_thread_events(db, flow.flow_id, section_name)
+                if state == FlowState.DONE:
+                    flow.done_thread_events = evts
+                elif state == FlowState.PLANNED:
+                    flow.planned_thread_events = evts
+                elif state == FlowState.BLOCKERS:
+                    flow.blockers_thread_events = evts
+                elif state == FlowState.NOTES:
+                    flow.notes_thread_events = evts
+
+            flows[row["user_id"]] = flow
+
+        return flows
+
+
+def new_flow() -> StandupFlow:
+    return StandupFlow(flow_id=str(uuid.uuid4()))

--- a/standupbot-maubot/standupbot/post.py
+++ b/standupbot-maubot/standupbot/post.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import Optional
 
 from mautrix.types import EventType, MessageType, RoomID
@@ -8,6 +9,27 @@ from .flow import FlowState, StandupFlow, StandupItem
 
 CHECKMARK = "✅"
 RED_X = "❌"
+
+
+def trim_reply_fallback_text(body: str) -> str:
+    if not body.startswith("> "):
+        return body
+    lines = body.split("\n")
+    i = 0
+    while i < len(lines) and lines[i].startswith("> "):
+        i += 1
+    if i < len(lines) and lines[i] == "":
+        i += 1
+    return "\n".join(lines[i:])
+
+
+def trim_reply_fallback_html(html: str) -> str:
+    if not html:
+        return html
+    match = re.match(r"^<mx-reply>.*?</mx-reply>", html, re.DOTALL)
+    if match:
+        return html[match.end():]
+    return html
 
 SECTION_QUESTIONS = {
     FlowState.DONE: "What did you get done since last time?",
@@ -154,6 +176,29 @@ async def send_to_send_room(
             },
         )
         return None
+
+    try:
+        members = await client.get_joined_members(send_room)
+        if sender not in members:
+            await client.send_message_event(
+                evt_room_id,
+                EventType.ROOM_MESSAGE,
+                {
+                    "msgtype": "m.notice",
+                    "body": "**You are not a member of the configured send room!** "
+                            "Refusing to send a message to the room. "
+                            "Set a new one using `!standupbot room [room ID or alias]`.",
+                    "format": "org.matrix.custom.html",
+                    "formatted_body": (
+                        "<b>You are not a member of the configured send room!</b> "
+                        "Refusing to send a message to the room. "
+                        "Set a new one using <code>!standupbot room [room ID or alias]</code>."
+                    ),
+                },
+            )
+            return None
+    except Exception:
+        pass
 
     post = format_post(sender, flow, preview=False, send_confirmation=False, is_edit_of_existing=False)
     post["space.nevarro.msc3464.on_behalf_of"] = sender

--- a/standupbot-maubot/standupbot/post.py
+++ b/standupbot-maubot/standupbot/post.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from mautrix.types import EventType, MessageType, RoomID
+
+from .flow import FlowState, StandupFlow, StandupItem
+
+CHECKMARK = "✅"
+RED_X = "❌"
+
+SECTION_QUESTIONS = {
+    FlowState.DONE: "What did you get done since last time?",
+    FlowState.PLANNED: "What are you planning to do next?",
+    FlowState.BLOCKERS: "Do you have any blockers?",
+    FlowState.NOTES: "Do you have any other notes?",
+}
+
+SECTION_LABELS = {
+    FlowState.DONE: "Done",
+    FlowState.PLANNED: "Planned",
+    FlowState.BLOCKERS: "Blockers",
+    FlowState.NOTES: "Notes",
+}
+
+
+def _format_list(items: list[StandupItem]) -> tuple[str, str]:
+    plain_lines = []
+    html_parts = []
+    for item in items:
+        plain_lines.append(f"- {item.body}")
+        html_parts.append(f"<li>{item.formatted_body or item.body}</li>")
+    return "\n".join(plain_lines), "".join(html_parts)
+
+
+def format_post(
+    user_id: str,
+    flow: StandupFlow,
+    preview: bool,
+    send_confirmation: bool,
+    is_edit_of_existing: bool,
+) -> dict:
+    post_text = f"{user_id}'s standup post:\n\n"
+    post_html = (
+        f'<a href="https://matrix.to/#/{user_id}">{user_id}</a>\'s standup post:<br><br>'
+    )
+
+    first_section = True
+    for state in (FlowState.DONE, FlowState.PLANNED, FlowState.BLOCKERS, FlowState.NOTES):
+        items = flow.get_section_list(state)
+        if not items:
+            continue
+        label = SECTION_LABELS[state]
+        plain, html = _format_list(items)
+        if not first_section:
+            post_text += "\n"
+        post_text += f"**{label}**\n{plain}"
+        post_html += f"<b>{label}</b><br><ul>{html}</ul>"
+        first_section = False
+
+    if preview:
+        post_text = (
+            "Standup post preview:\n"
+            "----------------------------------------\n"
+            + post_text
+        )
+        post_html = "<i>Standup post preview:</i><hr>" + post_html
+
+    if send_confirmation:
+        if is_edit_of_existing:
+            post_text += (
+                f"\n----------------------------------------\n"
+                f"Send Edit ({CHECKMARK}) or Cancel ({RED_X})?"
+            )
+            post_html += f"<hr><b>Send Edit ({CHECKMARK}) or Cancel ({RED_X})?</b>"
+        else:
+            post_text += (
+                f"\n----------------------------------------\n"
+                f"Send ({CHECKMARK}) or Cancel ({RED_X})?"
+            )
+            post_html += f"<hr><b>Send ({CHECKMARK}) or Cancel ({RED_X})?</b>"
+
+    return {
+        "msgtype": "m.text",
+        "body": post_text,
+        "format": "org.matrix.custom.html",
+        "formatted_body": post_html,
+    }
+
+
+async def show_message_preview(
+    client,
+    room_id: str,
+    user_id: str,
+    flow: StandupFlow,
+    is_edit_of_existing: bool,
+) -> str:
+    content = format_post(
+        user_id, flow, preview=True, send_confirmation=True,
+        is_edit_of_existing=is_edit_of_existing,
+    )
+    resp = await client.send_message_event(room_id, EventType.ROOM_MESSAGE, content)
+    await client.react(room_id, resp.event_id, CHECKMARK)
+    await client.react(room_id, resp.event_id, RED_X)
+    flow.preview_event_id = resp.event_id
+    flow.reactable_events.append(resp.event_id)
+    return resp.event_id
+
+
+async def edit_preview(
+    client,
+    room_id: str,
+    user_id: str,
+    flow: StandupFlow,
+) -> None:
+    new_content = format_post(
+        user_id, flow, preview=True, send_confirmation=True, is_edit_of_existing=False,
+    )
+    content = {
+        "msgtype": "m.text",
+        "body": " * " + new_content["body"],
+        "format": "org.matrix.custom.html",
+        "formatted_body": " * " + new_content["formatted_body"],
+        "m.relates_to": {
+            "rel_type": "m.replace",
+            "event_id": flow.preview_event_id,
+        },
+        "m.new_content": new_content,
+    }
+    resp = await client.send_message_event(room_id, EventType.ROOM_MESSAGE, content)
+    flow.reactable_events.append(resp.event_id)
+
+
+async def send_to_send_room(
+    client,
+    user_config,
+    evt_room_id: str,
+    sender: str,
+    flow: StandupFlow,
+    edit_event_id: Optional[str] = None,
+) -> Optional[str]:
+    send_room = user_config.get_send_room(sender)
+    if not send_room:
+        await client.send_message_event(
+            evt_room_id,
+            EventType.ROOM_MESSAGE,
+            {
+                "msgtype": "m.notice",
+                "body": "No send room set! Set one using `!standupbot room [room ID or alias]`.",
+                "format": "org.matrix.custom.html",
+                "formatted_body": (
+                    "No send room set! Set one using <code>!standupbot room [room ID or alias]</code>."
+                ),
+            },
+        )
+        return None
+
+    post = format_post(sender, flow, preview=False, send_confirmation=False, is_edit_of_existing=False)
+    post["space.nevarro.msc3464.on_behalf_of"] = sender
+
+    try:
+        sent_event_id: Optional[str] = None
+        if edit_event_id:
+            content = {
+                "msgtype": "m.text",
+                "body": " * " + post["body"],
+                "format": "org.matrix.custom.html",
+                "formatted_body": " * " + post["formatted_body"],
+                "space.nevarro.msc3464.on_behalf_of": sender,
+                "m.relates_to": {
+                    "rel_type": "m.replace",
+                    "event_id": edit_event_id,
+                },
+                "m.new_content": post,
+            }
+            await client.send_message_event(send_room, EventType.ROOM_MESSAGE, content)
+            sent_event_id = edit_event_id
+        else:
+            resp = await client.send_message_event(send_room, EventType.ROOM_MESSAGE, post)
+            sent_event_id = str(resp.event_id)
+
+        edit_str = " edit" if edit_event_id else ""
+        await client.send_message_event(
+            evt_room_id,
+            EventType.ROOM_MESSAGE,
+            {
+                "msgtype": "m.notice",
+                "body": f"Sent standup post{edit_str} to {send_room}",
+            },
+        )
+        flow.state = FlowState.SENT
+        flow.resend_event_id = None
+        return sent_event_id
+    except Exception:
+        edit_str = " edit" if edit_event_id else ""
+        await client.send_message_event(
+            evt_room_id,
+            EventType.ROOM_MESSAGE,
+            {
+                "msgtype": "m.notice",
+                "body": f"Failed to send standup post{edit_str} to {send_room}",
+            },
+        )
+        return None
+
+
+async def go_to_state_and_notify(
+    client,
+    room_id: str,
+    user_id: str,
+    flow: StandupFlow,
+    state: FlowState,
+    db,
+) -> None:
+    flow.state = state
+
+    if state == FlowState.THREADS:
+        content = {
+            "msgtype": "m.text",
+            "body": "**Fill out the standup post by replying in each thread.** *Enter one item per message.*",
+            "format": "org.matrix.custom.html",
+            "formatted_body": (
+                "<b>Fill out the standup post by replying in each thread.</b> "
+                "<i>Enter one item per message.</i>"
+            ),
+        }
+        resp = await client.send_message_event(room_id, EventType.ROOM_MESSAGE, content)
+        flow.reactable_events.append(resp.event_id)
+
+        for section_state, label in SECTION_LABELS.items():
+            thread_content = {
+                "msgtype": "m.text",
+                "body": f"**{label}** *(thread)*",
+                "format": "org.matrix.custom.html",
+                "formatted_body": f"<b>{label}</b> <i>(thread)</i>",
+            }
+            resp = await client.send_message_event(room_id, EventType.ROOM_MESSAGE, thread_content)
+            thread_events = flow.get_thread_events(section_state)
+            thread_events.clear()
+            thread_events.append(resp.event_id)
+
+        await show_message_preview(client, room_id, user_id, flow, is_edit_of_existing=False)
+    else:
+        question = SECTION_QUESTIONS[state]
+        content = {
+            "msgtype": "m.text",
+            "body": f"{question} *Enter one item per message. React with {CHECKMARK} when done.*",
+            "format": "org.matrix.custom.html",
+            "formatted_body": (
+                f"{question} <i>Enter one item per message. React with {CHECKMARK} when done.</i>"
+            ),
+        }
+        resp = await client.send_message_event(room_id, EventType.ROOM_MESSAGE, content)
+        await client.react(room_id, resp.event_id, CHECKMARK)
+        flow.reactable_events.append(resp.event_id)
+
+    await flow.save(db, user_id)

--- a/standupbot-maubot/standupbot/scheduler.py
+++ b/standupbot-maubot/standupbot/scheduler.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Callable, Awaitable, Dict, TYPE_CHECKING
+
+from mautrix.types import EventType, RoomID, UserID
+
+from .flow import FlowState
+
+if TYPE_CHECKING:
+    from .flow import StandupFlow
+    from .state_events import UserConfigCache
+
+
+class NotificationScheduler:
+    def __init__(
+        self,
+        client,
+        log,
+        user_config: UserConfigCache,
+        flows: Dict[str, StandupFlow],
+        start_flow_callback: Callable[[str, str], Awaitable[None]],
+    ):
+        self.client = client
+        self.log = log
+        self.user_config = user_config
+        self.flows = flows
+        self.start_flow_callback = start_flow_callback
+
+    async def run(self) -> None:
+        self.log.debug("Starting notification loop")
+        try:
+            while True:
+                try:
+                    users = self.user_config.get_users_to_notify_now()
+                    for user_id, room_id in users.items():
+                        await self._notify_user(user_id, room_id)
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    self.log.exception("Error in notification loop iteration")
+
+                seconds_until_next_minute = 60 - datetime.now(timezone.utc).second
+                await asyncio.sleep(seconds_until_next_minute)
+        except asyncio.CancelledError:
+            self.log.debug("Notification loop cancelled")
+
+    async def _notify_user(self, user_id: UserID, room_id: RoomID) -> None:
+        self.log.info(f"Notifying {user_id}")
+        uid = str(user_id)
+        flow = self.flows.get(uid)
+
+        if (
+            flow is None
+            or flow.state == FlowState.NOT_STARTED
+            or flow.state == FlowState.SENT
+        ):
+            await self.client.send_message_event(
+                room_id,
+                EventType.ROOM_MESSAGE,
+                {"msgtype": "m.text", "body": "Time to write your standup post!"},
+            )
+            await self.start_flow_callback(str(room_id), uid)
+        else:
+            await self.client.send_message_event(
+                room_id,
+                EventType.ROOM_MESSAGE,
+                {
+                    "msgtype": "m.text",
+                    "body": "Looks like you are already writing a standup post! If you want to start over, type `!standupbot new`",
+                    "format": "org.matrix.custom.html",
+                    "formatted_body": "Looks like you are already writing a standup post! If you want to start over, type <code>!standupbot new</code>",
+                },
+            )

--- a/standupbot-maubot/standupbot/state_events.py
+++ b/standupbot-maubot/standupbot/state_events.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Dict, Optional
+from zoneinfo import ZoneInfo
+
+from mautrix.types import EventType, RoomID, UserID
+
+STATE_TZ = EventType.find("com.nevarro.standupbot.timezone", t_class=EventType.Class.STATE)
+STATE_NOTIFY = EventType.find("com.nevarro.standupbot.notify", t_class=EventType.Class.STATE)
+STATE_SEND_ROOM = EventType.find("com.nevarro.standupbot.send_room", t_class=EventType.Class.STATE)
+STATE_USE_THREADS = EventType.find("com.nevarro.standupbot.use_threads", t_class=EventType.Class.STATE)
+STATE_PREVIOUS_POST = EventType.find("com.nevarro.standupbot.previous_post", t_class=EventType.Class.STATE)
+
+
+def state_key(user_id: UserID) -> str:
+    return str(user_id).lstrip("@")
+
+
+@dataclass
+class UserSettings:
+    config_room: Optional[RoomID] = None
+    timezone: Optional[str] = None
+    notify_minutes: Optional[int] = None
+    send_room: Optional[RoomID] = None
+    use_threads: bool = False
+
+
+class UserConfigCache:
+    def __init__(self, client, log):
+        self.client = client
+        self.log = log
+        self._users: Dict[UserID, UserSettings] = {}
+
+    def _ensure(self, user_id: UserID) -> UserSettings:
+        if user_id not in self._users:
+            self._users[user_id] = UserSettings()
+        return self._users[user_id]
+
+    # -- read methods (cache only) --
+
+    def get_config_room(self, user_id: UserID) -> Optional[RoomID]:
+        s = self._users.get(user_id)
+        return s.config_room if s else None
+
+    def get_timezone(self, user_id: UserID) -> Optional[ZoneInfo]:
+        s = self._users.get(user_id)
+        if not s or not s.timezone:
+            return None
+        try:
+            return ZoneInfo(s.timezone)
+        except (KeyError, Exception):
+            return None
+
+    def get_notify_minutes(self, user_id: UserID) -> Optional[int]:
+        s = self._users.get(user_id)
+        return s.notify_minutes if s else None
+
+    def get_send_room(self, user_id: UserID) -> Optional[RoomID]:
+        s = self._users.get(user_id)
+        return s.send_room if s else None
+
+    def get_use_threads(self, user_id: UserID) -> bool:
+        s = self._users.get(user_id)
+        return s.use_threads if s else False
+
+    # -- write methods --
+
+    def set_config_room(self, user_id: UserID, room_id: RoomID) -> None:
+        self._ensure(user_id).config_room = room_id
+
+    async def set_timezone(self, user_id: UserID, room_id: RoomID, tz_str: str) -> None:
+        sk = state_key(user_id)
+        await self.client.send_state_event(room_id, STATE_TZ, {"TzString": tz_str}, state_key=sk)
+        self._ensure(user_id).timezone = tz_str
+
+    async def set_notify(self, user_id: UserID, room_id: RoomID, minutes: int) -> None:
+        sk = state_key(user_id)
+        await self.client.send_state_event(
+            room_id, STATE_NOTIFY, {"MinutesAfterMidnight": minutes}, state_key=sk
+        )
+        self._ensure(user_id).notify_minutes = minutes
+
+    async def clear_notify(self, user_id: UserID, room_id: RoomID) -> None:
+        sk = state_key(user_id)
+        await self.client.send_state_event(room_id, STATE_NOTIFY, {}, state_key=sk)
+        s = self._users.get(user_id)
+        if s:
+            s.notify_minutes = None
+
+    async def set_send_room(
+        self, user_id: UserID, config_room_id: RoomID, send_room_id: RoomID
+    ) -> None:
+        sk = state_key(user_id)
+        await self.client.send_state_event(
+            config_room_id, STATE_SEND_ROOM, {"SendRoomID": str(send_room_id)}, state_key=sk
+        )
+        self._ensure(user_id).send_room = send_room_id
+
+    async def set_use_threads(self, user_id: UserID, room_id: RoomID, value: bool) -> None:
+        sk = state_key(user_id)
+        await self.client.send_state_event(
+            room_id, STATE_USE_THREADS, {"UseThreads": value}, state_key=sk
+        )
+        self._ensure(user_id).use_threads = value
+
+    async def populate_from_joined_rooms(self) -> None:
+        self.log.info("Loading user settings from joined rooms...")
+        try:
+            joined_rooms = await self.client.get_joined_rooms()
+        except Exception:
+            self.log.exception("Failed to get joined rooms")
+            return
+
+        for room_id in joined_rooms:
+            try:
+                members = await self.client.get_joined_members(room_id)
+            except Exception:
+                continue
+
+            for user_id in members:
+                sk = state_key(user_id)
+
+                try:
+                    content = await self.client.get_state_event(room_id, STATE_TZ, sk)
+                    tz_str = content.get("TzString", "") if content else ""
+                    if tz_str:
+                        ZoneInfo(tz_str)  # validate
+                        self.log.info(f"Loaded timezone ({tz_str}) for {user_id} from state")
+                        self.set_config_room(user_id, room_id)
+                        self._ensure(user_id).timezone = tz_str
+                except Exception:
+                    pass
+
+                try:
+                    content = await self.client.get_state_event(room_id, STATE_NOTIFY, sk)
+                    minutes = content.get("MinutesAfterMidnight") if content else None
+                    if minutes is not None:
+                        self.log.info(
+                            f"Loaded notification minutes ({minutes}) for {user_id} from state"
+                        )
+                        self.set_config_room(user_id, room_id)
+                        self._ensure(user_id).notify_minutes = minutes
+                except Exception:
+                    pass
+
+                try:
+                    content = await self.client.get_state_event(room_id, STATE_SEND_ROOM, sk)
+                    send_room = content.get("SendRoomID", "") if content else ""
+                    if send_room:
+                        self.log.info(f"Loaded send room ({send_room}) for {user_id} from state")
+                        self.set_config_room(user_id, room_id)
+                        self._ensure(user_id).send_room = RoomID(send_room)
+                except Exception:
+                    pass
+
+                try:
+                    content = await self.client.get_state_event(room_id, STATE_USE_THREADS, sk)
+                    if content:
+                        use_threads = content.get("UseThreads", False)
+                        self.log.info(
+                            f"Loaded thread usage setting ({use_threads}) for {user_id} from state"
+                        )
+                        self.set_config_room(user_id, room_id)
+                        self._ensure(user_id).use_threads = use_threads
+                except Exception:
+                    pass
+
+        self.log.info("Finished loading user settings from joined rooms")
+
+    def get_users_to_notify_now(self) -> Dict[UserID, RoomID]:
+        now_utc = datetime.now(timezone.utc)
+        current_utc_minutes = now_utc.hour * 60 + now_utc.minute
+        result: Dict[UserID, RoomID] = {}
+
+        for user_id, settings in self._users.items():
+            if settings.notify_minutes is None or settings.config_room is None:
+                continue
+
+            tz = self.get_timezone(user_id)
+            if tz is None:
+                continue
+
+            local_now = datetime.now(tz)
+            if local_now.weekday() >= 5:  # Saturday=5, Sunday=6
+                continue
+
+            local_midnight = local_now.replace(hour=0, minute=0, second=0, microsecond=0)
+            notify_local = local_midnight.replace(
+                hour=settings.notify_minutes // 60,
+                minute=settings.notify_minutes % 60,
+            )
+            notify_utc = notify_local.astimezone(timezone.utc)
+            notify_utc_minutes = notify_utc.hour * 60 + notify_utc.minute
+
+            if notify_utc_minutes == current_utc_minutes:
+                result[user_id] = settings.config_room
+
+        return result
+
+    def get_current_weekday_in_user_timezone(self, user_id: UserID) -> int:
+        tz = self.get_timezone(user_id)
+        if tz is None:
+            return datetime.now(timezone.utc).weekday()
+        return datetime.now(tz).weekday()


### PR DESCRIPTION
Rewrite the Go standup bot as a Python maubot plugin to support
modern Matrix homeserver authentication. Full feature parity with
the Go original: interactive standup flow, thread mode, edit-after-send,
reaction-based navigation, notification scheduling, MSC3464 on-behalf-of
posting, and user config via Matrix room state events.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>